### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,21 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth.engineering
+  namespace: eukarya-inc
+  description: https://reearth.engineering
+  annotations:
+    github.com/project-slug: eukarya-inc/reearth.engineering
+  links:
+    - url: https://github.com/eukarya-inc/reearth.engineering
+      title: GitHub
+      icon: github
+    - url: https://reearth.engineering
+      title: Website
+      icon: web
+  tags:
+    - astro
+spec:
+  type: service
+  lifecycle: experimental
+  owner: eukarya-inc/cto


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth.engineering` (namespace `eukarya-inc`)
- **Owner:** `eukarya-inc/cto`
- **Type / lifecycle:** `service` / `experimental`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.